### PR TITLE
Use hex.pm version of ExRLP

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule MerklePatriciaTree.Mixfile do
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
       {:hex_prefix, "~> 0.1.0"},
-      {:ex_rlp, github: "exthereum/ex_rlp"},
+      {:ex_rlp, "~> 0.2.0"},
       {:keccakf1600, "~> 2.0.0"},
       {:exleveldb, "~> 0.11.1"},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "eleveldb": {:hex, :eleveldb, "2.2.20", "1fff63a5055bbf4bf821f797ef76065882b193f5e8095f95fcd9287187773b58", [:rebar3], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "ex_rlp": {:git, "https://github.com/exthereum/ex_rlp.git", "262546b8705452a1893ab07638159dce0a410993", []},
+  "ex_rlp": {:hex, :ex_rlp, "0.2.0", "ba63b95e4dc8829e99bfe50533edc0edb2fc229e906701cedab1e4fb40e305a9", [:mix], [], "hexpm"},
   "exleveldb": {:hex, :exleveldb, "0.11.1", "37c0414208a50d2419d8246305e6c4a33ed339c25c0bdfa27774795e1e089f7b", [:mix], [{:eleveldb, "~> 2.2.19", [hex: :eleveldb, repo: "hexpm", optional: false]}], "hexpm"},
   "hex_prefix": {:hex, :hex_prefix, "0.1.0", "e96b5cbb6ad8493196ce193726240023f5ce0ae0753118a19a5b43e2db0267ca", [:mix], [], "hexpm"},
   "keccakf1600": {:hex, :keccakf1600, "2.0.0", "69d02d844a101bf3c75484c9e334fd04b0f57280727e881cac3bd8240432f43a", [:rebar3], [], "hexpm"}}


### PR DESCRIPTION
This patch simply moves our usage of ExRLP on to the version published on hex.pm so that we can now publish this package.