### PR TITLE
Add destroyer and common tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ jobs:
       - image: elixir:latest
     steps:
       - checkout
+      - run: git submodule sync --recursive
+      - run: git submodule update --recursive --init
       - restore_cache:
           key: _build
       - run: mix local.hex --force

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/ethereum_common_tests"]
+	path = test/support/ethereum_common_tests
+	url = git@github.com:ethereum/tests.git

--- a/lib/trie.ex
+++ b/lib/trie.ex
@@ -38,14 +38,16 @@ defmodule MerklePatriciaTree.Trie do
   ## Examples
 
     iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(:trie_test_1))
-    %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :trie_test_1}, root_hash: <<128>>}
+    %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :trie_test_1}, root_hash: <<197, 210, 70, 1, 134, 247, 35, 60, 146, 126, 125, 178, 220, 199, 3, 192, 229, 0, 182, 83, 202, 130, 39, 59, 123, 250, 216, 4, 93, 133, 164, 112>>}
 
     iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(:trie_test_2), <<1, 2, 3>>)
-    %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :trie_test_2}, root_hash: <<1, 2, 3>>}
+    %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :trie_test_2}, root_hash: <<241, 136, 94, 218, 84, 183, 160, 83, 49, 140, 212, 30, 32, 147, 34, 13, 171, 21, 214, 83, 129, 177, 21, 122, 54, 51, 168, 59, 253, 92, 146, 57>>}
 
     iex> trie = MerklePatriciaTree.Trie.new(MerklePatriciaTree.DB.LevelDB.init("/tmp/#{MerklePatriciaTree.Test.random_string(20)}"), <<1, 2, 3>>)
     iex> trie.root_hash
-    <<1, 2, 3>>
+    <<241, 136, 94, 218, 84, 183, 160, 83, 49, 140, 212, 30, 32, 147, 34,
+      13, 171, 21, 214, 83, 129, 177, 21, 122, 54, 51, 168, 59, 253, 92,
+      146, 57>>
     iex> {db, _db_ref} = trie.db
     iex> db
     MerklePatriciaTree.DB.LevelDB
@@ -138,7 +140,7 @@ defmodule MerklePatriciaTree.Trie do
   def store(trie) do
     root_hash = if not is_binary(trie.root_hash), do: ExRLP.encode(trie.root_hash), else: trie.root_hash
 
-    if byte_size(root_hash) < 32 do
+    if byte_size(root_hash) < MerklePatriciaTree.Trie.Storage.max_rlp_len do
       %{trie | root_hash: root_hash |> MerklePatriciaTree.Trie.Storage.store(trie.db)}
     else
       trie

--- a/lib/trie.ex
+++ b/lib/trie.ex
@@ -136,8 +136,10 @@ defmodule MerklePatriciaTree.Trie do
   end
 
   def store(trie) do
-    if byte_size(trie.root_hash) < 32 do
-      %{trie | root_hash: trie.root_hash |> MerklePatriciaTree.Trie.Storage.store(trie.db)}
+    root_hash = if not is_binary(trie.root_hash), do: ExRLP.encode(trie.root_hash), else: trie.root_hash
+
+    if byte_size(root_hash) < 32 do
+      %{trie | root_hash: root_hash |> MerklePatriciaTree.Trie.Storage.store(trie.db)}
     else
       trie
     end

--- a/lib/trie/builder.ex
+++ b/lib/trie/builder.ex
@@ -9,13 +9,12 @@ defmodule MerklePatriciaTree.Trie.Builder do
   number of functional and invariant tests. We should add more specific
   unit tests to this module.
 
-  TODO: Test
   """
   alias MerklePatriciaTree.Trie
   alias MerklePatriciaTree.Trie.Node
   alias MerklePatriciaTree.ListHelper
 
-  @empty_branch Node.encode_node(:empty, nil)
+  @empty_branch <<>>
 
   @doc """
   Adds a key-value pair to a given trie.

--- a/lib/trie/builder.ex
+++ b/lib/trie/builder.ex
@@ -67,8 +67,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
         # [] -> {16, {:encoded, old_value}} # TODO: Is this right?
         [h|[]] -> {h, {:encoded, old_value}}
         [h|t] ->
-          leaf_encoded = {:leaf, [], old_value} |> Node.encode_node(trie)
-          ext_encoded = {:ext, t, leaf_encoded} |> Node.encode_node(trie)
+          ext_encoded = {:ext, t, old_value} |> Node.encode_node(trie)
 
           {h, {:encoded, ext_encoded}}
       end

--- a/lib/trie/destroyer.ex
+++ b/lib/trie/destroyer.ex
@@ -12,7 +12,6 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
   """
   alias MerklePatriciaTree.Trie
   alias MerklePatriciaTree.Trie.Node
-  alias MerklePatriciaTree.ListHelper
 
   @empty_branch Node.encode_node(:empty, nil)
 

--- a/lib/trie/destroyer.ex
+++ b/lib/trie/destroyer.ex
@@ -1,0 +1,99 @@
+defmodule MerklePatriciaTree.Trie.Destroyer do
+  @moduledoc """
+  Destroyer is responsible for removing keys from a
+  merkle trie. To remove a key, we need to make a
+  delta to our trie which ends up as the canonical
+  form of the given tree as defined in http://gavwood.com/Paper.pdf.
+
+  Note: this algorithm is non-obvious, and hence why we have a good
+  number of functional and invariant tests. We should add more specific
+  unit tests to this module.
+
+  """
+  alias MerklePatriciaTree.Trie
+  alias MerklePatriciaTree.Trie.Node
+  alias MerklePatriciaTree.ListHelper
+
+  @empty_branch Node.encode_node(:empty, nil)
+
+  @doc """
+  Removes a key from a given trie, if it exists.
+
+  This may radically change the structure of the trie.
+  """
+  def remove_key(trie_node, key, trie) do
+    IO.inspect(["Removing", trie_node, key, trie])
+    trie_remove_key(trie_node, key, trie)
+  end
+
+  # To remove this leaf, simply remove it
+  defp trie_remove_key({:leaf, leaf_prefix, _value}, prefix, _trie) when prefix == leaf_prefix do
+    :empty
+  end
+
+  # This key doesn't exist, do nothing.
+  defp trie_remove_key({:leaf, leaf_prefix, value}, prefix, _trie) do
+    {:leaf, leaf_prefix, value}
+  end
+
+  # Shed shared prefix and continue removal operation
+  defp trie_remove_key({:ext, ext_prefix, node_hash}, [ext_prefix | remaining_prefix], trie) do
+    existing_node = Node.decode_trie(node_hash |> Trie.into(trie))
+    updated_node = trie_remove_key(existing_node, remaining_prefix, trie)
+
+    # Handle the potential cases of children
+    case updated_node do
+      :empty -> :empty
+      {:leaf, leaf_prefix, leaf_value} -> {:leaf, ext_prefix ++ leaf_prefix, leaf_value}
+      {:ext, new_ext_prefix, new_ext_node_hash} -> {:ext, ext_prefix ++ new_ext_prefix, new_ext_node_hash}
+      els -> {:ext, ext_prefix, els}
+    end
+  end
+
+  # Prefix doesn't match ext, do nothing.
+  defp trie_remove_key({:ext, ext_prefix, node_hash}, _prefix, _trie) do
+    {:ext, ext_prefix, node_hash}
+  end
+
+  # Remove from a branch when directly on value
+  defp trie_remove_key({:branch, branches}, [], _trie) when length(branches) == 17 do
+    {:branch, List.replace_at(branches, 16, nil)}
+  end
+
+  # Remove beneath a branch
+  # TODO: Handle removing when only have one branch option left
+  defp trie_remove_key({:branch, branches}, [prefix_hd|prefix_tl], trie) when length(branches) == 17 do
+    updated_branches = List.update_at(branches, prefix_hd, fn branch ->
+      branch_node = branch |> Trie.into(trie) |> Node.decode_trie
+
+      remove_key(branch_node, prefix_tl, trie) |> IO.inspect |> Node.encode_node(trie) |> IO.inspect
+    end)
+
+    non_blank_branches =
+      updated_branches
+      |> Enum.drop(-1)
+      |> Enum.with_index
+      |> Enum.filter(fn {branch, _} -> branch != @empty_branch end)
+
+    final_value = List.last(updated_branches)
+
+    cond do
+      Enum.count(non_blank_branches) == 0 ->
+        # We just have a final value, this will need to percolate up
+        {:leaf, [] , final_value}
+      Enum.count(non_blank_branches) == 1 and final_value == nil ->
+        # We just have a node we need to percolate up
+        {branch_node, i} = List.first(non_blank_branches)
+
+        # TODO: This is illegal since ext has to have at least two items
+        {:ext, [i], branch_node}
+      true -> {:branch, updated_branches}
+    end
+  end
+
+  # Merge into empty to create a leaf
+  defp trie_remove_key(:empty, _prefix, _value, _trie) do
+    :empty
+  end
+
+end

--- a/lib/trie/destroyer.ex
+++ b/lib/trie/destroyer.ex
@@ -22,7 +22,6 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
   This may radically change the structure of the trie.
   """
   def remove_key(trie_node, key, trie) do
-    IO.inspect(["Removing", trie_node, key, trie])
     trie_remove_key(trie_node, key, trie)
   end
 
@@ -66,7 +65,7 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
     updated_branches = List.update_at(branches, prefix_hd, fn branch ->
       branch_node = branch |> Trie.into(trie) |> Node.decode_trie
 
-      remove_key(branch_node, prefix_tl, trie) |> IO.inspect |> Node.encode_node(trie) |> IO.inspect
+      remove_key(branch_node, prefix_tl, trie) |> Node.encode_node(trie)
     end)
 
     non_blank_branches =

--- a/lib/trie/node.ex
+++ b/lib/trie/node.ex
@@ -46,14 +46,7 @@ defmodule MerklePatriciaTree.Trie.Node do
   def encode_node(trie_node, trie) do
     trie_node
     |> encode_node_type()
-    |> maybe_store(trie)
-  end
-
-  defp maybe_store(x, trie) do
-    case ExRLP.encode(x) do
-      encoded when byte_size(encoded) >= @max_rlp_len -> Storage.store(encoded, trie.db)
-      _ -> x
-    end
+    |> Storage.put_node(trie)
   end
 
   defp encode_node_type({:leaf, key, value}) do

--- a/lib/trie/node.ex
+++ b/lib/trie/node.ex
@@ -16,8 +16,6 @@ defmodule MerklePatriciaTree.Trie.Node do
     {:ext, [integer()], binary()} |
     {:branch, [binary()]}
 
-  @max_rlp_len 32
-
   @doc """
   Given a node, this function will encode the node
   and put the value to storage (for nodes that are
@@ -32,15 +30,15 @@ defmodule MerklePatriciaTree.Trie.Node do
 
   iex> trie = MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
   iex> MerklePatriciaTree.Trie.Node.encode_node({:leaf, [5,6,7], "ok"}, trie)
-  <<198, 130, 53, 103, 130, 111, 107>>
+  ["5g", "ok"]
 
   iex> trie = MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
   iex> MerklePatriciaTree.Trie.Node.encode_node({:branch, [<<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>, <<>>]}, trie)
-  <<209, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128>>
+  ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
 
   iex> trie = MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
   iex> MerklePatriciaTree.Trie.Node.encode_node({:ext, [1, 2, 3], <<>>}, trie)
-  <<196, 130, 17, 35, 128>>
+  [<<17, 35>>, ""]
   """
   @spec encode_node(trie_node, Trie.t) :: nil | binary()
   def encode_node(trie_node, trie) do

--- a/lib/trie/storage.ex
+++ b/lib/trie/storage.ex
@@ -30,7 +30,7 @@ defmodule MerklePatriciaTree.Trie.Storage do
   def put_node(rlp_encoded_node, trie) do
     case byte_size(rlp_encoded_node) do
       0 -> <<>> # nil is nil
-      x when x < @max_rlp_len -> rlp_encoded_node # return node itself
+      x when x < @max_rlp_len -> x # return node itself
       _ ->
         store(rlp_encoded_node, trie.db)
     end
@@ -75,8 +75,8 @@ defmodule MerklePatriciaTree.Trie.Storage do
   @spec get_node(Trie.t) :: ExRLP.t
   def get_node(trie) do
     case trie.root_hash do
-      <<>> -> <<>> # nil
-      x when byte_size(x) < @max_rlp_len -> ExRLP.decode(x) # stored directly
+      <<>> -> <<>>
+      x when not is_binary(x) -> x # stored directly
       h ->
         case DB.get(trie.db, h) do # stored in db
           {:ok, v} -> ExRLP.decode(v)

--- a/lib/trie/storage.ex
+++ b/lib/trie/storage.ex
@@ -10,6 +10,9 @@ defmodule MerklePatriciaTree.Trie.Storage do
 
   @max_rlp_len 32
 
+  @spec max_rlp_len() :: integer()
+  def max_rlp_len(), do: @max_rlp_len
+
   @doc """
   Takes an RLP-encoded node and pushes it to storage,
   as defined by `n(I, i)` Eq.(178) of the Yellow Paper.
@@ -28,7 +31,7 @@ defmodule MerklePatriciaTree.Trie.Storage do
       iex> MerklePatriciaTree.Trie.Storage.put_node(<<>>, trie)
       <<>>
       iex> MerklePatriciaTree.Trie.Storage.put_node("Hi", trie)
-      <<130, 72, 105>>
+      "Hi"
       iex> MerklePatriciaTree.Trie.Storage.put_node(["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"], trie)
       <<141, 163, 93, 242, 120, 27, 128, 97, 138, 56, 116, 101, 165, 201,
              165, 139, 86, 73, 85, 153, 45, 38, 207, 186, 196, 202, 111, 84,
@@ -62,7 +65,7 @@ defmodule MerklePatriciaTree.Trie.Storage do
 
     iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(), <<>>)
     ...> |> MerklePatriciaTree.Trie.Storage.get_node()
-    ""
+    nil
 
     iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(), <<130, 72, 105>>)
     ...> |> MerklePatriciaTree.Trie.Storage.get_node()
@@ -73,8 +76,10 @@ defmodule MerklePatriciaTree.Trie.Storage do
     ** (RuntimeError) Cannot find value in DB: <<254, 112, 17, 90, 21, 82, 19, 29, 72, 106, 175, 110, 87, 220, 249, 140, 74, 165, 64, 94, 174, 79, 78, 189, 145, 143, 92, 53, 173, 136, 220, 145>>
 
     iex> trie = MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(), <<130, 72, 105>>)
-    iex> MerklePatriciaTree.Trie.Storage.put_node(ExRLP.encode(["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]), trie)
-    <<141, 163, 93, 242, 120, 27, 128, 97, 138, 56, 116, 101, 165, 201, 165, 139, 86, 73, 85, 153, 45, 38, 207, 186, 196, 202, 111, 84, 214, 26, 122, 164>>
+    iex> MerklePatriciaTree.Trie.Storage.put_node(["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"], trie)
+    <<141, 163, 93, 242, 120, 27, 128, 97, 138, 56, 116, 101, 165, 201,
+      165, 139, 86, 73, 85, 153, 45, 38, 207, 186, 196, 202, 111, 84,
+      214, 26, 122, 164>>
     iex> MerklePatriciaTree.Trie.Storage.get_node(%{trie| root_hash: <<141, 163, 93, 242, 120, 27, 128, 97, 138, 56, 116, 101, 165, 201, 165, 139, 86, 73, 85, 153, 45, 38, 207, 186, 196, 202, 111, 84, 214, 26, 122, 164>>})
     ["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]
   """

--- a/lib/trie/storage.ex
+++ b/lib/trie/storage.ex
@@ -18,7 +18,7 @@ defmodule MerklePatriciaTree.Trie.Storage do
 
       iex> trie = MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
       iex> MerklePatriciaTree.Trie.Storage.put_node(<<>>, trie)
-      nil
+      <<>>
       iex> MerklePatriciaTree.Trie.Storage.put_node(ExRLP.encode("Hi"), trie)
       <<130, 72, 105>>
       iex> MerklePatriciaTree.Trie.Storage.put_node(ExRLP.encode(["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]), trie)
@@ -26,18 +26,26 @@ defmodule MerklePatriciaTree.Trie.Storage do
              165, 139, 86, 73, 85, 153, 45, 38, 207, 186, 196, 202, 111, 84,
              214, 26, 122, 164>>
   """
-  @spec put_node(ExRLP.t, Trie.t) :: nil | binary()
+  @spec put_node(ExRLP.t, Trie.t) :: binary()
   def put_node(rlp_encoded_node, trie) do
     case byte_size(rlp_encoded_node) do
-      0 -> nil # nil is nil
+      0 -> <<>> # nil is nil
       x when x < @max_rlp_len -> rlp_encoded_node # return node itself
       _ ->
-        node_hash = :keccakf1600.sha3_256(rlp_encoded_node) # sha3
-
-        DB.put!(trie.db, node_hash, rlp_encoded_node) # store in db
-
-        node_hash # return hash
+        store(rlp_encoded_node, trie.db)
     end
+  end
+
+  @doc """
+  TODO: Doc and test
+  """
+  @spec store(ExRLP.t, MerklePatriciaTree.DB.db) :: binary()
+  def store(rlp_encoded_node, db) do
+    node_hash = :keccakf1600.sha3_256(rlp_encoded_node) # sha3
+
+    DB.put!(db, node_hash, rlp_encoded_node) # store in db
+
+    node_hash # return hash
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,7 @@ defmodule MerklePatriciaTree.Mixfile do
   defp deps do
     [
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
+      {:poison, "~> 3.1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
       {:hex_prefix, "~> 0.1.0"},
       {:ex_rlp, "~> 0.2.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -8,4 +8,5 @@
   "exleveldb": {:hex, :exleveldb, "0.11.1", "37c0414208a50d2419d8246305e6c4a33ed339c25c0bdfa27774795e1e089f7b", [:mix], [{:eleveldb, "~> 2.2.19", [hex: :eleveldb, repo: "hexpm", optional: false]}], "hexpm"},
   "hex_prefix": {:hex, :hex_prefix, "0.1.0", "e96b5cbb6ad8493196ce193726240023f5ce0ae0753118a19a5b43e2db0267ca", [:mix], [], "hexpm"},
   "keccakf1600": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [:rebar3], [], "hexpm"},
-  "keccakf1600_orig": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [:rebar3], [], "hexpm"}}
+  "keccakf1600_orig": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [:rebar3], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"}}

--- a/test/merkle_patricia_tree_test.exs
+++ b/test/merkle_patricia_tree_test.exs
@@ -1,4 +1,60 @@
 defmodule MerklePatriciaTreeTest do
   use ExUnit.Case
 
+  alias MerklePatriciaTree.Trie
+
+  @passing_tests %{
+    anyorder: [
+      :singleItem,
+      :dogs
+    ]
+  }
+
+  test "Ethereum Common Tests" do
+    for {test_type, test_group} <- @passing_tests do
+      for {test_name, test} <- read_test_file(test_type),
+        Enum.member?(test_group, String.to_atom(test_name)) do
+
+        db = MerklePatriciaTree.Test.random_ets_db()
+        test_in = test["in"]
+
+        input = if is_map(test_in) do
+          test_in
+            |> Enum.into([])
+            |> Enum.map(fn {a,b} -> [a,b] end)
+            |> Enum.shuffle
+        else
+          test_in
+        end
+
+        trie = Enum.reduce(input, Trie.new(db), fn [k, v], trie ->
+          IO.inspect(["Adding key", k, v, trie])
+          Trie.update(trie, k, v)
+        end)
+
+        assert trie.root_hash == test["root"] |> hex_to_binary
+      end
+    end
+  end
+
+  def read_test_file(type) do
+    {:ok, body} = File.read(test_file_name(type))
+    Poison.decode!(body)
+  end
+
+  def test_file_name(type) do
+    "test/support/ethereum_common_tests/TrieTests/trie#{Macro.camelize(Atom.to_string(type))}.json" |> IO.inspect
+  end
+
+  def hex_to_binary(string) do
+    string
+    |> String.slice(2..-1)
+    |> Base.decode16!(case: :mixed)
+  end
+
+  def hex_to_int(string) do
+    hex_to_binary(string)
+    |> :binary.decode_unsigned
+  end
+
 end

--- a/test/merkle_patricia_tree_test.exs
+++ b/test/merkle_patricia_tree_test.exs
@@ -44,7 +44,7 @@ defmodule MerklePatriciaTreeTest do
   end
 
   def test_file_name(type) do
-    "test/support/ethereum_common_tests/TrieTests/trie#{Macro.camelize(Atom.to_string(type))}.json"
+    "test/support/ethereum_common_tests/TrieTests/trie#{Atom.to_string(type)}.json"
   end
 
   def maybe_hex("0x" <> _str=hex_string), do: hex_to_binary(hex_string)

--- a/test/merkle_patricia_tree_test.exs
+++ b/test/merkle_patricia_tree_test.exs
@@ -6,7 +6,10 @@ defmodule MerklePatriciaTreeTest do
   @passing_tests %{
     anyorder: [
       :singleItem,
-      :dogs
+      :dogs,
+      :foo,
+      :smallValues,
+      :puppy
     ]
   }
 

--- a/test/merkle_patricia_tree_test.exs
+++ b/test/merkle_patricia_tree_test.exs
@@ -39,7 +39,7 @@ defmodule MerklePatriciaTreeTest do
   end
 
   def read_test_file(type) do
-    {:ok, body} = File.read(test_file_name(type))
+    {:ok, body} = File.read(test_file_name(type) |> IO.inspect)
     Poison.decode!(body)
   end
 

--- a/test/trie_test.exs
+++ b/test/trie_test.exs
@@ -126,9 +126,14 @@ defmodule MerklePatriciaTree.TrieTest do
       assert Trie.get(trie_2, <<0x01::4, 0x02::4>>) == nil
       assert Trie.get(trie_2, <<0x01::4, 0x02::4, 0x03::4>>) == "cool"
       assert Trie.get(trie_2, <<0x01::4, 0x02::4, 0x03::4, 0x04::4>>) == nil
+    end
 
-      # assert Trie.root(trie) == nil
-      # assert Trie.root(trie_2) == "cool root"
+    test "from blog post", %{db: db} do
+      trie = Trie.new(db)
+
+      trie_2 = Trie.update(trie, <<0x01::4, 0x01::4, 0x02::4>>, "hello")
+
+      assert trie_2.root_hash == "4a5b19d151e796482b08a1e020f1f7ef5ea7240c0171fd629598fee612892a7b"
     end
 
     test "update a leaf value (when stored directly)", %{db: db} do

--- a/test/trie_test.exs
+++ b/test/trie_test.exs
@@ -14,7 +14,7 @@ defmodule MerklePatriciaTree.TrieTest do
   end
 
   def leaf_node(key_end, value) do
-    ExRLP.encode([HexPrefix.encode({key_end, true}), value])
+    [HexPrefix.encode({key_end, true}), value]
   end
 
   def store(node_value, db) do
@@ -25,11 +25,11 @@ defmodule MerklePatriciaTree.TrieTest do
   end
 
   def extension_node(shared_nibbles, node_hash) do
-    ExRLP.encode([HexPrefix.encode({shared_nibbles, false}), node_hash])
+    [HexPrefix.encode({shared_nibbles, false}), node_hash]
   end
 
   def branch_node(branches, value) when length(branches) == 16 do
-    ExRLP.encode(branches ++ [value])
+    branches ++ [value]
   end
 
   def blanks(n) do
@@ -72,7 +72,7 @@ defmodule MerklePatriciaTree.TrieTest do
 
     test "for a trie with an extension node followed by a leaf", %{db: db} do
       trie = Trie.new(db)
-      trie = %{trie| root_hash: extension_node([0x01, 0x02], leaf_node([0x03], "cool"))}
+      trie = %{trie| root_hash: extension_node([0x01, 0x02], leaf_node([0x03], "cool")) |> ExRLP.encode |> store(db)}
 
       assert Trie.get(trie, <<0x01::4>>) == nil
       assert Trie.get(trie, <<0x01::4, 0x02::4>>) == nil
@@ -82,7 +82,7 @@ defmodule MerklePatriciaTree.TrieTest do
 
     test "for a trie with an extension node followed by an extension node and then leaf", %{db: db} do
       trie = Trie.new(db)
-      trie = %{trie| root_hash: extension_node([0x01, 0x02], extension_node([0x03], leaf_node([0x04], "cool")))}
+      trie = %{trie| root_hash: extension_node([0x01, 0x02], extension_node([0x03], leaf_node([0x04], "cool"))) |> ExRLP.encode |> store(db)}
 
       assert Trie.get(trie, <<0x01::4>>) == nil
       assert Trie.get(trie, <<0x01::4, 0x02::4>>) == nil
@@ -93,7 +93,7 @@ defmodule MerklePatriciaTree.TrieTest do
 
     test "for a trie with a branch node", %{db: db} do
       trie = Trie.new(db)
-      trie = %{trie| root_hash: extension_node([0x01], branch_node([leaf_node([0x02], "hi")|blanks(15)], "cool"))}
+      trie = %{trie| root_hash: extension_node([0x01], branch_node([leaf_node([0x02], "hi")|blanks(15)], "cool")) |> ExRLP.encode |> store(db)}
 
       assert Trie.get(trie, <<0x01::4>>) == "cool"
       assert Trie.get(trie, <<0x01::4, 0x00::4>>) == nil
@@ -106,7 +106,7 @@ defmodule MerklePatriciaTree.TrieTest do
       long_string = Enum.join(for _ <- 1..60, do: "A")
 
       trie = Trie.new(db)
-      trie = %{trie| root_hash: extension_node([0x01, 0x02], leaf_node([0x03], long_string) |> store(db)) |> store(db)}
+      trie = %{trie| root_hash: extension_node([0x01, 0x02], leaf_node([0x03], long_string) |> ExRLP.encode |> store(db)) |> ExRLP.encode |> store(db)}
 
       assert Trie.get(trie, <<0x01::4>>) == nil
       assert Trie.get(trie, <<0x01::4, 0x02::4>>) == nil
@@ -133,7 +133,7 @@ defmodule MerklePatriciaTree.TrieTest do
 
       trie_2 = Trie.update(trie, <<0x01::4, 0x01::4, 0x02::4>>, "hello")
 
-      assert trie_2.root_hash == "4a5b19d151e796482b08a1e020f1f7ef5ea7240c0171fd629598fee612892a7b"
+      assert trie_2.root_hash == <<73, 98, 206, 73, 94, 192, 23, 36, 174, 248, 169, 73, 103, 133, 200, 167, 68, 83, 86, 207, 246, 91, 200, 242, 14, 115, 208, 252, 28, 74, 245, 130>>
     end
 
     test "update a leaf value (when stored directly)", %{db: db} do
@@ -148,7 +148,7 @@ defmodule MerklePatriciaTree.TrieTest do
       long_string = Enum.join(for _ <- 1..60, do: "A")
       long_string_2 = Enum.join(for _ <- 1..60, do: "B")
 
-      trie = Trie.new(db, leaf_node([0x01, 0x02], long_string) |> store(db))
+      trie = Trie.new(db, leaf_node([0x01, 0x02], long_string) |> ExRLP.encode |> store(db))
       trie_2 = Trie.update(trie, <<0x01::4, 0x02::4>>, long_string_2)
 
       assert Trie.get(trie, <<0x01::4, 0x02::4>>) == long_string


### PR DESCRIPTION
This patch starts to look for correctness under Common Tests. We add a destroyer function, which removes keys from a merkle trie, and we begin to test against common tests. We are currently trying to make sure we properly define branch definitions, which tend to be the most complicated to get right.