### PR TITLE
Fix several cases for removing nodes from a trie

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add `:merkle_patricia_tree` as a dependency to your project's `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:merkle_patricia_tree, "~> 0.2.0"}
+    {:merkle_patricia_tree, "~> 0.2.4"}
   ]
 end
 ```

--- a/lib/trie.ex
+++ b/lib/trie.ex
@@ -38,7 +38,7 @@ defmodule MerklePatriciaTree.Trie do
   ## Examples
 
     iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(:trie_test_1))
-    %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :trie_test_1}, root_hash: <<197, 210, 70, 1, 134, 247, 35, 60, 146, 126, 125, 178, 220, 199, 3, 192, 229, 0, 182, 83, 202, 130, 39, 59, 123, 250, 216, 4, 93, 133, 164, 112>>}
+    %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :trie_test_1}, root_hash: <<86, 232, 31, 23, 27, 204, 85, 166, 255, 131, 69, 230, 146, 192, 248, 110, 91, 72, 224, 27, 153, 108, 173, 192, 1, 98, 47, 181, 227, 99, 180, 33>>}
 
     iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(:trie_test_2), <<1, 2, 3>>)
     %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :trie_test_2}, root_hash: <<241, 136, 94, 218, 84, 183, 160, 83, 49, 140, 212, 30, 32, 147, 34, 13, 171, 21, 214, 83, 129, 177, 21, 122, 54, 51, 168, 59, 253, 92, 146, 57>>}
@@ -138,7 +138,7 @@ defmodule MerklePatriciaTree.Trie do
   end
 
   def store(trie) do
-    root_hash = if not is_binary(trie.root_hash), do: ExRLP.encode(trie.root_hash), else: trie.root_hash
+    root_hash = if not is_binary(trie.root_hash) or trie.root_hash == <<>>, do: ExRLP.encode(trie.root_hash), else: trie.root_hash
 
     if byte_size(root_hash) < MerklePatriciaTree.Trie.Storage.max_rlp_len do
       %{trie | root_hash: root_hash |> MerklePatriciaTree.Trie.Storage.store(trie.db)}

--- a/lib/trie/builder.ex
+++ b/lib/trie/builder.ex
@@ -21,6 +21,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
 
   This may radically change the structure of the trie.
   """
+  @spec put_key(Node.trie_node, Trie.key, ExRLP.t, Trie.t) :: Node.trie_node
   def put_key(trie_node, key, value, trie) do
     trie_put_key(trie_node, key, value, trie)
   end

--- a/lib/trie/destroyer.ex
+++ b/lib/trie/destroyer.ex
@@ -13,7 +13,7 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
   alias MerklePatriciaTree.Trie
   alias MerklePatriciaTree.Trie.Node
 
-  @empty_branch Node.encode_node(:empty, nil)
+  @empty_branch <<>>
 
   @doc """
   Removes a key from a given trie, if it exists.
@@ -79,7 +79,7 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
       Enum.count(non_blank_branches) == 0 ->
         # We just have a final value, this will need to percolate up
         {:leaf, [] , final_value}
-      Enum.count(non_blank_branches) == 1 and final_value == nil ->
+      Enum.count(non_blank_branches) == 1 and final_value == "" ->
         # We just have a node we need to percolate up
         {branch_node, i} = List.first(non_blank_branches)
 

--- a/lib/trie/storage.ex
+++ b/lib/trie/storage.ex
@@ -65,7 +65,7 @@ defmodule MerklePatriciaTree.Trie.Storage do
 
     iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(), <<>>)
     ...> |> MerklePatriciaTree.Trie.Storage.get_node()
-    nil
+    <<>>
 
     iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(), <<130, 72, 105>>)
     ...> |> MerklePatriciaTree.Trie.Storage.get_node()

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule MerklePatriciaTree.Mixfile do
 
   def project do
     [app: :merkle_patricia_tree,
-      version: "0.2.3",
+      version: "0.2.4",
       elixir: "~> 1.4",
       description: "Ethereum's Merkle Patricia Trie data structure",
       package: [

--- a/test/merkle_patricia_tree_test.exs
+++ b/test/merkle_patricia_tree_test.exs
@@ -5,12 +5,7 @@ defmodule MerklePatriciaTreeTest do
 
   @passing_tests %{
     anyorder: :all,
-    test: [
-      :emptyValues,
-      # :branchingTests,
-      # :jeff,
-      :"insert-middle-leaf",
-    ]
+    test: :all
   }
 
   test "Ethereum Common Tests" do

--- a/test/merkle_patricia_tree_test.exs
+++ b/test/merkle_patricia_tree_test.exs
@@ -6,7 +6,10 @@ defmodule MerklePatriciaTreeTest do
   @passing_tests %{
     anyorder: :all,
     test: [
-      :"insert-middle-leaf"
+      :emptyValues,
+      # :branchingTests,
+      # :jeff,
+      :"insert-middle-leaf",
     ]
   }
 
@@ -39,7 +42,7 @@ defmodule MerklePatriciaTreeTest do
   end
 
   def read_test_file(type) do
-    {:ok, body} = File.read(test_file_name(type) |> IO.inspect)
+    {:ok, body} = File.read(test_file_name(type))
     Poison.decode!(body)
   end
 


### PR DESCRIPTION
This patch fixes a few cases for removing nodes from a trie. We still haven't matched all test cases, but we're just about head on in all but two cases.