### PR TITLE
Add back empty trie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.5
+* Add back empty trie function :(
+# 0.2.4
+* Remove empty trie function
+# 0.2.3
+* Add key deletion and tie out rest of tests
 # 0.2.2
 * Add typespec for an empty trie.
 # 0.2.1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add `:merkle_patricia_tree` as a dependency to your project's `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:merkle_patricia_tree, "~> 0.2.4"}
+    {:merkle_patricia_tree, "~> 0.2.5"}
   ]
 end
 ```

--- a/lib/trie.ex
+++ b/lib/trie.ex
@@ -20,18 +20,23 @@ defmodule MerklePatriciaTree.Trie do
   @type key :: binary()
 
   @empty_trie <<>>
+  @empty_trie_root_hash @empty_trie |> ExRLP.encode |> :keccakf1600.sha3_256
 
   @doc """
   Returns the canonical empty trie.
 
+  Note: this root hash will not be accessible unless you have stored
+  the result in a db. If you are initializing a new trie, instead of
+  checking a result is empty, it's strongly recommended you use
+  `Trie.new(db).root_hash`.
+
   ## Examples
 
-      iex> db = MerklePatriciaTree.Test.random_ets_db()
-      iex> MerklePatriciaTree.Trie.empty_trie_root_hash(db)
+      iex> MerklePatriciaTree.Trie.empty_trie_root_hash()
       <<86, 232, 31, 23, 27, 204, 85, 166, 255, 131, 69, 230, 146, 192, 248, 110, 91, 72, 224, 27, 153, 108, 173, 192, 1, 98, 47, 181, 227, 99, 180, 33>>
   """
-  @spec empty_trie_root_hash(DB.db) :: root_hash
-  def empty_trie_root_hash(db), do: new(db).root_hash
+  @spec empty_trie_root_hash() :: root_hash
+  def empty_trie_root_hash(), do: @empty_trie_root_hash
 
   @doc """
   Contructs a new unitialized trie.

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule MerklePatriciaTree.Mixfile do
 
   def project do
     [app: :merkle_patricia_tree,
-      version: "0.2.4",
+      version: "0.2.5",
       elixir: "~> 1.4",
       description: "Ethereum's Merkle Patricia Trie data structure",
       package: [


### PR DESCRIPTION
While it's annoying to have an empty trie, and it's very likely that will be abused, it's just so darned useful to have as a default value for anything that requires a root hash as it's initial value (e.g. for a Blockchain.Block's state_root, transactions_root and receipts_root). As such, we'll add this back in with a note and why it's a bad idea to overuse it.