### PR TITLE
Don't raise on key not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.2.6
+* Don't raise on key not found
 # 0.2.5
 * Add back empty trie function :(
 # 0.2.4

--- a/lib/trie.ex
+++ b/lib/trie.ex
@@ -87,6 +87,7 @@ defmodule MerklePatriciaTree.Trie do
 
     case Node.decode_trie(trie) do
       :empty -> nil # no node, bail
+      :not_found -> :not_found
       {:branch, branches} ->
         # branch node
         case Enum.at(branches, nibble) do

--- a/lib/trie.ex
+++ b/lib/trie.ex
@@ -87,7 +87,6 @@ defmodule MerklePatriciaTree.Trie do
 
     case Node.decode_trie(trie) do
       :empty -> nil # no node, bail
-      :not_found -> :not_found
       {:branch, branches} ->
         # branch node
         case Enum.at(branches, nibble) do

--- a/lib/trie/node.ex
+++ b/lib/trie/node.ex
@@ -91,7 +91,7 @@ defmodule MerklePatriciaTree.Trie.Node do
     case Storage.get_node(trie) do
       nil -> :empty
       <<>> -> :empty
-      :not_found -> :not_found
+      :not_found -> :empty
       branches when length(branches) == 17 ->
         {:branch, branches}
       [hp_k, v] ->

--- a/lib/trie/node.ex
+++ b/lib/trie/node.ex
@@ -91,6 +91,7 @@ defmodule MerklePatriciaTree.Trie.Node do
     case Storage.get_node(trie) do
       nil -> :empty
       <<>> -> :empty
+      :not_found -> :not_found
       branches when length(branches) == 17 ->
         {:branch, branches}
       [hp_k, v] ->

--- a/lib/trie/storage.ex
+++ b/lib/trie/storage.ex
@@ -84,7 +84,7 @@ defmodule MerklePatriciaTree.Trie.Storage do
     iex> MerklePatriciaTree.Trie.Storage.get_node(%{trie| root_hash: <<141, 163, 93, 242, 120, 27, 128, 97, 138, 56, 116, 101, 165, 201, 165, 139, 86, 73, 85, 153, 45, 38, 207, 186, 196, 202, 111, 84, 214, 26, 122, 164>>})
     ["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]
   """
-  @spec get_node(Trie.t) :: ExRLP.t
+  @spec get_node(Trie.t) :: ExRLP.t | :not_found
   def get_node(trie) do
     case trie.root_hash do
       <<>> -> <<>>

--- a/lib/trie/storage.ex
+++ b/lib/trie/storage.ex
@@ -73,7 +73,8 @@ defmodule MerklePatriciaTree.Trie.Storage do
 
     iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(), <<254, 112, 17, 90, 21, 82, 19, 29, 72, 106, 175, 110, 87, 220, 249, 140, 74, 165, 64, 94, 174, 79, 78, 189, 145, 143, 92, 53, 173, 136, 220, 145>>)
     ...> |> MerklePatriciaTree.Trie.Storage.get_node()
-    ** (RuntimeError) Cannot find value in DB: <<254, 112, 17, 90, 21, 82, 19, 29, 72, 106, 175, 110, 87, 220, 249, 140, 74, 165, 64, 94, 174, 79, 78, 189, 145, 143, 92, 53, 173, 136, 220, 145>>
+    :not_found
+
 
     iex> trie = MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db(), <<130, 72, 105>>)
     iex> MerklePatriciaTree.Trie.Storage.put_node(["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"], trie)
@@ -91,7 +92,7 @@ defmodule MerklePatriciaTree.Trie.Storage do
       h ->
         case DB.get(trie.db, h) do # stored in db
           {:ok, v} -> ExRLP.decode(v)
-          :not_found -> raise "Cannot find value in DB: #{inspect trie.root_hash}"
+          :not_found -> :not_found
         end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule MerklePatriciaTree.Mixfile do
 
   def project do
     [app: :merkle_patricia_tree,
-      version: "0.2.5",
+      version: "0.2.6",
       elixir: "~> 1.4",
       description: "Ethereum's Merkle Patricia Trie data structure",
       package: [


### PR DESCRIPTION
This allows you to check whether a value is set without having to
use exception handling.